### PR TITLE
deps: updates wazero to 1.0.0-pre.4

### DIFF
--- a/node/go.mod
+++ b/node/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-ipfs-api v0.3.0
 	github.com/multiformats/go-multihash v0.2.1
-	github.com/tetratelabs/wazero v1.0.0-pre.1
+	github.com/tetratelabs/wazero v1.0.0-pre.4
 	github.com/tyler-smith/go-bip39 v1.1.0
 	github.com/umbracle/ethgo v0.1.3
 	github.com/web3-storage/go-w3s-client v0.0.6

--- a/node/go.sum
+++ b/node/go.sum
@@ -1378,8 +1378,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/tetratelabs/wazero v1.0.0-pre.1 h1:bUZ4vf21c36RmgA3enNOlLgPElEVDYoRJJ9+McRGF6Q=
-github.com/tetratelabs/wazero v1.0.0-pre.1/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
+github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/texttheater/golang-levenshtein v0.0.0-20180516184445-d188e65d659e/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=

--- a/node/lit/wasm.go
+++ b/node/lit/wasm.go
@@ -101,11 +101,11 @@ func NewWasmInstance(ctx context.Context) (*Wasm, error) {
 	r := wazero.NewRuntime(ctx)
 	h := &StringHeap{}
 
-	if _, err := r.NewModuleBuilder("wbg").
-		ExportFunction("__wbindgen_throw", wbingenThrow).
-		ExportFunction("__wbindgen_object_drop_ref", h.wbingenObjectDropRef).
-		ExportFunction("__wbindgen_string_new", h.wbingenStringNew).
-		ExportFunction("__wbg_log_9a99fb1af846153b", h.wbingenLog9a99fb1af846153b).
+	if _, err := r.NewHostModuleBuilder("wbg").
+		NewFunctionBuilder().WithFunc(wbingenThrow).Export("__wbindgen_throw").
+		NewFunctionBuilder().WithFunc(h.wbingenObjectDropRef).Export("__wbindgen_object_drop_ref").
+		NewFunctionBuilder().WithFunc(h.wbingenStringNew).Export("__wbindgen_string_new").
+		NewFunctionBuilder().WithFunc(h.wbingenLog9a99fb1af846153b).Export("__wbg_log_9a99fb1af846153b").
 		Instantiate(ctx, r); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.4](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.4).

Notably, v1.0.0-pre.4:
* improves module initialization speed
* supports listeners in the compiler engine
* supports WASI `fd_pread`, `fd_readdir` and `path_filestat_get`
* breaks GoModuleFunc API